### PR TITLE
Enable and expose ECDH

### DIFF
--- a/config/discover.ml
+++ b/config/discover.ml
@@ -21,6 +21,7 @@ let symbols =
     Some ("SECP256K1_TAG_PUBKEY_HYBRID_EVEN", Some "0x06");
     Some ("SECP256K1_TAG_PUBKEY_HYBRID_ODD", Some "0x07");
     Some ("ENABLE_MODULE_RECOVERY", None);
+    Some ("ENABLE_MODULE_ECDH", None)
   ]
 
 let generate_defines symbols =

--- a/src/external.ml
+++ b/src/external.ml
@@ -501,3 +501,11 @@ module Sign = struct
     try Ok (recover_exn ctx ~signature msg)
     with Invalid_argument msg -> Error msg
 end
+
+module Ecdh = struct
+  external ecdh :
+  Context.t -> Bigstring.t -> Bigstring.t -> Bigstring.t -> int
+  = "caml_secp256k1_ecdh"
+
+  let ecdh ctx ~pk ~sk buf = ecdh ctx buf (Key.buffer pk) (Key.buffer sk)
+end

--- a/src/external.mli
+++ b/src/external.mli
@@ -243,3 +243,8 @@ module Sign : sig
     Bigstring.t ->
     (Key.public Key.t, string) result
 end
+
+module Ecdh : sig
+  (** [ecdh ctx ~pk ~sk ~f ~sk ~ss] computes an EC Diffie-Hellman secret in constant time. *)
+  val ecdh : Context.t -> pk:Key.public Key.t -> sk:Key.secret Key.t -> Bigstring.t -> int
+end

--- a/src/secp256k1_wrap.c
+++ b/src/secp256k1_wrap.c
@@ -6,6 +6,7 @@
 
 #include "secp256k1.h"
 #include "secp256k1_recovery.h"
+#include "secp256k1_ecdh.h"
 
 /* Accessing the secp256k1_context * part of an OCaml custom block */
 #define Context_val(v) (*((secp256k1_context **) Data_custom_val(v)))
@@ -221,4 +222,11 @@ CAMLprim value caml_secp256k1_ecdsa_recover(value ctx, value buf, value signatur
                                             Caml_ba_data_val(buf),
                                             Caml_ba_data_val(signature),
                                             Caml_ba_data_val(msg)));
+}
+
+CAMLprim value caml_secp256k1_ecdh(value ctx, value buf, value pk, value sk) {
+    return Val_int(secp256k1_ecdh(Context_val(ctx),
+                                  Caml_ba_data_val(buf),
+                                  Caml_ba_data_val(pk),
+                                  Caml_ba_data_val(sk)));
 }


### PR DESCRIPTION
Example higher-level wrapping call:

```ocaml
let ecdh ~context ~pk ~sk =
  (* ECDH(k, rk): performs an Elliptic-Curve Diffie-Hellman operation using sk, which
     is a valid secp256k1 private key, and pk, which is a valid public key

    The returned value is the SHA256 of the compressed format of the generated point. *)
  let cstruct = Cstruct.create 32 in
  let retval = Secp256k1.Ecdh.ecdh context ~pk ~sk cstruct.Cstruct.buffer in
  if Int.( <> ) retval 1
  then failwithf "ecdh: exponentian failed: scalar was invalid (zero or overflow)" ();
  cstruct
```